### PR TITLE
Root skolemization

### DIFF
--- a/lean4/Skolem.lean
+++ b/lean4/Skolem.lean
@@ -3,8 +3,6 @@ import Lean
 open Classical
 open Lean Elab Meta Tactic Expr
 
-#check skolem
-
 /-- Applies recursive skolemization in a given hypothesis -/
 elab "skolemize_hypothesis" h:Parser.Tactic.locationHyp : tactic => do
   evalTactic (← `(tactic| simp only [skolem] at $h))
@@ -27,7 +25,16 @@ that the goal is of the form ∀x, ∃y, P x y. -/
 elab "root_skolemize_goal" : tactic => do
   evalTactic (← `(tactic| apply skolem.mpr))
 
--- def skolemForwards := skolem.mp
+-- Helper definitions for use in the hypothesis root skolemization tactic
+@[reducible] def skolem1.{u, v} {α : Sort u} {b : α → Sort v} {p : (x : α) → b x → Prop} :=
+  ∀ x : α, ∃ y : b x, p x y
+
+@[reducible] def skolem2.{u, v} {α : Sort u} {b : α → Sort v} {p : (x : α) → b x → Prop} :=
+  ∃ f : (x : α) → b x, ∀ x : α, p x (f x)
+
+def skolemEquality.{u, v}
+  {α : Sort u} {b : α → Sort v} {p : (x : α) → b x → Prop} :=
+  propext (@skolem.{u, v} (α : Sort u) (b : α → Sort v) (p : (x : α) → b x → Prop))
 
 /-- Root skolemization only applies skolemization once, in the case
 that the hypothesis is of the form ∀x, ∃y, P x y. -/
@@ -37,10 +44,20 @@ elab "root_skolemize_hypothesis" h:term : tactic => do
     match hExpr with
     | fvar fvarId =>
       liftMetaTactic fun goal => do
-        -- let originalProp ←
-        -- let newProp := .app
-        let proof := const ``Classical.skolem
-        let assert ← goal.replaceLocalDecl fvarId newProp proof
-        let goal' ← return goal
-        return [goal']
-    | _ => logError m!"{h} is not a hypothesis"
+        let originalProp ← inferType hExpr
+        let u ← mkFreshLevelMVar
+        let v ← mkFreshLevelMVar
+        let a ← mkFreshExprMVar (sort u)
+        let b ← mkFreshExprMVar none
+        let p ← mkFreshExprMVar none
+        let metaOriginalProp := mkApp3 (const ``skolem1 [u, v]) a b p
+        if ← isDefEq metaOriginalProp originalProp then
+          let newProp ← withTransparency .reducible (reduce (skipTypes:= false)
+            (mkApp3 (const ``skolem2 [u, v]) a b p))
+          let proof := mkApp3 (const ``skolemEquality [u, v]) a b p
+          let assertAfterResult ← goal.replaceLocalDecl fvarId newProp proof
+          return [assertAfterResult.mvarId]
+        else logError (m!"Error in root_skolemize_hypothesis: {h} " ++
+                        m!"is not of the form ∀ x, ∃ y, p x y")
+          return [goal]
+    | _ => logError m!"Error in root_skolemize_hypothesis: {h} is not a hypothesis"

--- a/lean4/Skolem.lean
+++ b/lean4/Skolem.lean
@@ -1,7 +1,9 @@
 import Lean
 
 open Classical
-open Lean Elab Tactic
+open Lean Elab Meta Tactic Expr
+
+#check skolem
 
 /-- Applies recursive skolemization in a given hypothesis -/
 elab "skolemize_hypothesis" h:Parser.Tactic.locationHyp : tactic => do
@@ -19,3 +21,26 @@ elab "skolemize_all" : tactic => do
 /-- Applies recursive skolemization everywhere (all goals affected) -/
 elab "skolemize_everything" : tactic => do
   evalTactic (← `(tactic| all_goals skolemize_all))
+
+/-- Root skolemization only applies skolemization once, in the case
+that the goal is of the form ∀x, ∃y, P x y. -/
+elab "root_skolemize_goal" : tactic => do
+  evalTactic (← `(tactic| apply skolem.mpr))
+
+-- def skolemForwards := skolem.mp
+
+/-- Root skolemization only applies skolemization once, in the case
+that the hypothesis is of the form ∀x, ∃y, P x y. -/
+elab "root_skolemize_hypothesis" h:term : tactic => do
+  withMainContext do
+    let hExpr ← elabTerm h none
+    match hExpr with
+    | fvar fvarId =>
+      liftMetaTactic fun goal => do
+        -- let originalProp ←
+        -- let newProp := .app
+        let proof := const ``Classical.skolem
+        let assert ← goal.replaceLocalDecl fvarId newProp proof
+        let goal' ← return goal
+        return [goal']
+    | _ => logError m!"{h} is not a hypothesis"

--- a/lean4/Tidying.lean
+++ b/lean4/Tidying.lean
@@ -8,7 +8,7 @@ def tidyingReduce : Expr → MetaM Expr := fun e =>
   (withTransparency .instances (reduce (skipTypes := false) e))
 
 /-- Modifies a goal by tidying the type of the target -/
-def metaTidyGoal : MVarId -> MetaM (MVarId) :=
+def metaTidyGoal : MVarId -> MetaM MVarId :=
   fun originalGoal => do
     let originalType ← originalGoal.getType
     let newType ← tidyingReduce originalType
@@ -18,7 +18,7 @@ def metaTidyGoal : MVarId -> MetaM (MVarId) :=
 
 /-- Modifies all declarations (e.g. hypotheses) associated with a goal
 -/
-def metaTidyDeclarations : MVarId -> MetaM (MVarId) :=
+def metaTidyDeclarations : MVarId -> MetaM MVarId :=
   fun goal => do
     let mut goal' := goal
     for decl in ← getLCtx do

--- a/lean4/tests/test_skolem.lean
+++ b/lean4/tests/test_skolem.lean
@@ -12,7 +12,7 @@ example (f : Nat → Nat) (hf : ∀ x : Nat , ∃ y : Nat, f y > x) :
   skolemize_hypothesis hf
   exact hf
 
---advanced skolemization tests
+-- advanced skolemization tests
 example : ∀ x : Nat, ∀ y : Nat, ∃ z : Nat, z > x + y := by
   skolemize_all
   exists (λ x y => x + y + 1)
@@ -23,3 +23,9 @@ example {p : Prop} (hP : p) (f : Nat → Nat)
   ∃ g : Nat → Nat, ∀ x : Nat, (f ∘ g) x > x := by
   skolemize_everything
   exact (h' hP).right
+
+-- root skolemization tests
+example : ∀ x : Nat, ∃ y : Nat, y > x := by
+  root_skolemize_goal
+  exists (λ x => x + 1)
+  simp

--- a/lean4/tests/test_skolem.lean
+++ b/lean4/tests/test_skolem.lean
@@ -29,3 +29,8 @@ example : ∀ x : Nat, ∃ y : Nat, y > x := by
   root_skolemize_goal
   exists (λ x => x + 1)
   simp
+
+example (f : Nat → Nat) (hf : ∀ x : Nat , ∃ y : Nat, f y > x) :
+  ∃ g : Nat → Nat, ∀ x : Nat, (f ∘ g) x > x := by
+  root_skolemize_hypothesis hf
+  exact hf


### PR DESCRIPTION
Skolemization tactics that only apply at the root level, i.e. if a hypothesis or goal is of the form \forall x \exists y. Only acts on those two quantifiers.